### PR TITLE
fix github banner collision with recording

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -6,17 +6,19 @@
 
 html, body {
   height: 100%;
-}
-
-body {
+  display: flex;
+  flex-direction: column;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 0.8rem;
+  justify-content: space-between;
 }
 
 .wrapper {
-  height: 100%;
   display: flex;
+  width: 100%;
   flex-direction: column;
+  overflow-y: scroll;
+  padding: 1em;
 }
 
 header {
@@ -212,11 +214,12 @@ input[type=checkbox]:checked ~ aside {
 /* Adjustments for wider screens */
 @media all and (min-width: 800px) {
   /* Don't take all the space as readability is lost when line length
-     goes past a certain size */
+      goes past a certain size */
   .wrapper {
     width: 90%;
     max-width: 1000px;
     margin: 0 auto;
+    overflow-y: auto;
   }
 }
 
@@ -235,12 +238,11 @@ input[type=checkbox]:checked ~ aside {
 
 
 .source-code {
-  position: absolute;
-  left: 0;
-  right: 0;
+  width: 100%;
   bottom: 0;
   background: #eeeeee;
   padding: .5rem 0;
+  flex-shrink: 0;
 }
 
 .repo-link {


### PR DESCRIPTION
**ISSUE**:  github footer blocks UI on mobile devices (see BEFORE)
**FIX**:   use flex layout for `body` , `wrapper` and `source-code` blocks to improve layout on mobile devices.  

## BEFORE
https://user-images.githubusercontent.com/397995/221079938-2d369ce0-9f29-4d53-b77b-f7c2db6b8884.mov

## AFTER
https://user-images.githubusercontent.com/397995/221079961-3d654ebc-3d7d-41e7-bfb8-4e3db9323310.mov

